### PR TITLE
M1: Lavalink templated config + compose topology + Makefile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,5 @@ build: ## Build all images without starting
 deploy: ## Production deploy (run on the VM)
 	git pull origin master && $(COMPOSE) up -d --build
 
-reauth: ## Re-run YouTube OAuth device flow (playbook F2)
+reauth: ## YouTube OAuth device flow (legacy stack script; v2 flow lands in M2)
 	./scripts/reauth-youtube.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+COMPOSE := docker compose -f deploy/docker-compose.yml --env-file deploy/.env
+
+.PHONY: help up down restart logs ps test lint build deploy reauth
+
+help: ## List commands
+	@grep -E '^[a-z-]+:.*##' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  make %-10s %s\n", $$1, $$2}'
+
+up: ## Start the stack
+	$(COMPOSE) up -d --build
+
+down: ## Stop the stack
+	$(COMPOSE) down
+
+restart: ## Restart one service: make restart s=lavalink
+	$(COMPOSE) restart $(s)
+
+logs: ## Tail logs (all, or one: make logs s=bot)
+	$(COMPOSE) logs -f --tail=100 $(s)
+
+ps: ## Show service status
+	$(COMPOSE) ps
+
+test: ## Run all unit tests
+	cd services/bot && python -m pytest tests/ -q
+	cd services/guardian && python -m pytest tests/ -q
+
+lint: ## Ruff over both services
+	ruff check services/bot services/guardian
+
+build: ## Build all images without starting
+	$(COMPOSE) build
+
+deploy: ## Production deploy (run on the VM)
+	git pull origin master && $(COMPOSE) up -d --build
+
+reauth: ## Re-run YouTube OAuth device flow (playbook F2)
+	./scripts/reauth-youtube.sh

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,23 @@
+# ── Discord ──────────────────────────────────────────────────────────────
+# Bot token: Discord Developer Portal → your app → Bot → Token
+DISCORD_TOKEN=changeme
+
+# Discord webhook URL for guardian alerts (Server Settings → Integrations →
+# Webhooks → New Webhook in your admin channel)
+ALERT_WEBHOOK_URL=changeme
+
+# ── Lavalink ─────────────────────────────────────────────────────────────
+# Shared secret between bot/guardian and Lavalink. Generate: openssl rand -hex 16
+LAVALINK_PASSWORD=changeme
+
+# JVM heap. 512m fits the 2GB VM budget (see spec §2 constraints).
+LAVALINK_HEAP=512m
+
+# ── YouTube source ───────────────────────────────────────────────────────
+# THE ONLY PLACE the youtube-source plugin version is declared (spec §3.2).
+# Latest releases: https://github.com/lavalink-devs/youtube-source/releases
+YOUTUBE_PLUGIN_VERSION=1.18.1
+
+# OAuth refresh token (playbook F2). Obtain/rotate with: make reauth
+# May be empty; poToken layer (M2) carries playback without it.
+YOUTUBE_OAUTH_REFRESH_TOKEN=

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,52 @@
+name: jacky-music
+
+services:
+  lavalink:
+    build: ../services/lavalink
+    container_name: jacky-lavalink
+    restart: unless-stopped
+    environment:
+      _JAVA_OPTIONS: "-Xmx${LAVALINK_HEAP:-512m}"
+      LAVALINK_SERVER_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
+      YOUTUBE_PLUGIN_VERSION: ${YOUTUBE_PLUGIN_VERSION:?set in .env}
+      YOUTUBE_OAUTH_REFRESH_TOKEN: ${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
+    expose:
+      - "2333"
+    volumes:
+      - tokens:/data/tokens:ro
+    networks: [jacky]
+
+  bot:
+    build: ../services/bot
+    container_name: jacky-bot
+    restart: unless-stopped
+    environment:
+      DISCORD_TOKEN: ${DISCORD_TOKEN:?set in .env}
+      LAVALINK_HOST: lavalink
+      LAVALINK_PORT: "2333"
+      LAVALINK_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
+    depends_on:
+      - lavalink
+    networks: [jacky]
+
+  guardian:
+    build: ../services/guardian
+    container_name: jacky-guardian
+    restart: unless-stopped
+    environment:
+      LAVALINK_HOST: lavalink
+      LAVALINK_PORT: "2333"
+      LAVALINK_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
+      ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:?set in .env}
+    volumes:
+      # Guardian's only privilege: restarting sibling containers (playbook F4/F5).
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - lavalink
+    networks: [jacky]
+
+networks:
+  jacky: {}
+
+volumes:
+  tokens: {}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,8 +3,14 @@ name: jacky-music
 services:
   lavalink:
     build: ../services/lavalink
-    container_name: jacky-lavalink
     restart: unless-stopped
+    # Rotation is load-bearing: a revoked OAuth token (playbook F2) makes the
+    # youtube plugin log errors every 5s; unbounded logs once filled the VM disk.
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       _JAVA_OPTIONS: "-Xmx${LAVALINK_HEAP:-512m}"
       LAVALINK_SERVER_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
@@ -18,8 +24,12 @@ services:
 
   bot:
     build: ../services/bot
-    container_name: jacky-bot
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       DISCORD_TOKEN: ${DISCORD_TOKEN:?set in .env}
       LAVALINK_HOST: lavalink
@@ -31,15 +41,20 @@ services:
 
   guardian:
     build: ../services/guardian
-    container_name: jacky-guardian
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       LAVALINK_HOST: lavalink
       LAVALINK_PORT: "2333"
       LAVALINK_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
       ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:?set in .env}
     volumes:
-      # Guardian's only privilege: restarting sibling containers (playbook F4/F5).
+      # Root-equivalent access to the host, accepted by design (spec §3.4):
+      # guardian uses it only to restart sibling services (playbook F4/F5).
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - lavalink

--- a/services/lavalink/Dockerfile
+++ b/services/lavalink/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/lavalink-devs/lavalink:4
+USER root
+COPY application.yml.tmpl /opt/Lavalink/application.yml.tmpl
+COPY entrypoint.sh /opt/Lavalink/entrypoint.sh
+RUN chmod +x /opt/Lavalink/entrypoint.sh
+USER lavalink
+ENTRYPOINT ["/opt/Lavalink/entrypoint.sh"]

--- a/services/lavalink/application.yml.tmpl
+++ b/services/lavalink/application.yml.tmpl
@@ -1,0 +1,44 @@
+server:
+  port: 2333
+  address: 0.0.0.0
+
+lavalink:
+  plugins:
+    - dependency: "dev.lavalink.youtube:youtube-plugin:__YOUTUBE_PLUGIN_VERSION__"
+      repository: "https://maven.lavalink.dev/releases"
+      snapshot: false
+  server:
+    password: "${LAVALINK_SERVER_PASSWORD}"
+    sources:
+      youtube: false  # handled by youtube-plugin above
+
+plugins:
+  youtube:
+    enabled: true
+    allowSearch: true
+    allowDirectVideoIds: true
+    allowDirectPlaylistIds: true
+    # Client order matters: Lavalink tries top-to-bottom until one resolves.
+    # MUSIC: search-only. TVHTML5_SIMPLY first for playback: TV-class IP
+    # reputation survives datacenter IPs. TV last: carries OAuth for
+    # sign-in-gated streams (metadata support: none, useless alone).
+    clients:
+      - MUSIC
+      - TVHTML5_SIMPLY
+      - WEB
+      - WEBEMBEDDED
+      - ANDROID_VR
+      - TV
+    clientOptions:
+      MUSIC:
+        playback: false
+        videoLoading: false
+    oauth:
+      enabled: true
+      refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN:}"
+      skipInitialization: false
+
+logging:
+  level:
+    root: INFO
+    lavalink: INFO

--- a/services/lavalink/entrypoint.sh
+++ b/services/lavalink/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+: "${YOUTUBE_PLUGIN_VERSION:?YOUTUBE_PLUGIN_VERSION must be set (see deploy/.env.example)}"
+sed "s|__YOUTUBE_PLUGIN_VERSION__|${YOUTUBE_PLUGIN_VERSION}|g" \
+    /opt/Lavalink/application.yml.tmpl > /tmp/application.yml
+# classpath:/ keeps the jar's built-in defaults (incl. the spring.config.import
+# property Spring Cloud requires); our rendered file, listed last, overrides them.
+export SPRING_CONFIG_LOCATION="classpath:/,file:/tmp/application.yml"
+exec java -jar /opt/Lavalink/Lavalink.jar

--- a/services/lavalink/entrypoint.sh
+++ b/services/lavalink/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eu
 : "${YOUTUBE_PLUGIN_VERSION:?YOUTUBE_PLUGIN_VERSION must be set (see deploy/.env.example)}"
+case "$YOUTUBE_PLUGIN_VERSION" in
+  *[!A-Za-z0-9._-]*) echo "YOUTUBE_PLUGIN_VERSION contains invalid characters" >&2; exit 1 ;;
+esac
 sed "s|__YOUTUBE_PLUGIN_VERSION__|${YOUTUBE_PLUGIN_VERSION}|g" \
     /opt/Lavalink/application.yml.tmpl > /tmp/application.yml
 # classpath:/ keeps the jar's built-in defaults (incl. the spring.config.import


### PR DESCRIPTION
## What

- `services/lavalink/`: Lavalink v4 image whose `application.yml` is rendered at container start — the youtube-source plugin version exists **only** in `.env` (config/jar drift, our recurring F3 outage, is now structurally impossible). Secrets resolve via Spring env placeholders, never written to disk. Input-validated, LF-enforced entrypoint.
- `deploy/docker-compose.yml`: three-service topology (lavalink/bot/guardian) + tokens volume (ready for M2's token-minter), log rotation on every service (the unbounded-log incident is documented inline), docker.sock confined to guardian with an honest blast-radius comment, no ports published to the internet, no fixed container names (M5 coexistence with the legacy stack).
- `deploy/.env.example`: every variable documented. `Makefile`: the single operational interface (`make help`).

## Why

Closes #20. Plan Tasks 5–7. **Stacked on #24** — merge that first; GitHub will retarget this to master.

## Test evidence

- Rendered config verified: `youtube-plugin:1.18.1` dependency line
- Real boot: `Started Launcher in 4.913s`, `Loaded 'youtube-plugin-1.18.1.jar' (17 classes)`
- Injection guard: `YOUTUBE_PLUGIN_VERSION='1.18|evil'` → rejected, exit 1
- `docker compose config -q` → OK; ruff clean; 8/8 unit tests pass
- Two-stage subagent review: spec ✅; quality approved after fixing container-name collision, restoring log rotation, adding input guard

## Checklist

- [x] No secrets in the diff (deploy/.env git-ignored, verified)
- [x] Legacy stack untouched
- [x] RUNBOOK-relevant behavior documented inline (rotation/F2, sock/F4-F5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a templated Lavalink v4 service and standardized Docker-based stack topology with a Makefile-driven operational interface.

New Features:
- Add a Lavalink service image that renders its configuration from a template at container startup based on environment variables.
- Define a three-service docker-compose stack (lavalink, bot, guardian) with an internal network and shared tokens volume.
- Provide a Makefile as the primary interface for starting, stopping, building, deploying, and inspecting the stack.

Enhancements:
- Configure structured log rotation for all services in the docker-compose stack to prevent unbounded log growth.
- Restrict docker.sock access to the guardian service in the compose topology to limit blast radius.
- Validate the YouTube plugin version via the Lavalink container entrypoint before rendering configuration to avoid invalid dependency injection.

Documentation:
- Add an example deploy/.env file to document required and optional environment variables for the stack.