### PR TITLE
M1: CI pipeline + issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+---
+name: Bug
+about: Something is broken
+labels: type:bug
+---
+
+## Observed
+
+## Expected
+
+## Playbook ID (if from a guardian alert)
+
+<!-- F1-F9, see docs/operations/RUNBOOK.md -->
+
+## Logs / evidence

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,15 @@
+---
+name: Feature
+about: A unit of planned work
+labels: type:feature
+---
+
+## Goal
+
+## Acceptance criteria
+
+- [ ]
+
+## Plan reference
+
+<!-- e.g. docs/superpowers/plans/2026-07-02-stability-rewrite-m1-foundation.md Task N -->

--- a/.github/ISSUE_TEMPLATE/ops-incident.md
+++ b/.github/ISSUE_TEMPLATE/ops-incident.md
@@ -1,0 +1,17 @@
+---
+name: Ops incident
+about: Production outage or degradation post-mortem
+labels: type:ops
+---
+
+## Timeline
+
+## Playbook ID + was detection automatic?
+
+## Root cause
+
+## What would have prevented it
+
+## Follow-up actions
+
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What
+
+<!-- One paragraph: what this PR does -->
+
+## Why
+
+<!-- Link the issue: Closes #N -->
+
+## Test evidence
+
+<!-- Paste test run output or describe manual verification -->
+
+## Checklist
+
+- [ ] CI green
+- [ ] Docs updated (service README / ARCHITECTURE.md) if behavior changed
+- [ ] RUNBOOK.md updated if failure/recovery behavior changed
+- [ ] No secrets in the diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install ruff
+      # Pinned: red CI blocks merge, so lint rules may only change via a deliberate bump
+      - run: pip install "ruff==0.15.20"
       - run: ruff check services/bot services/guardian
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff
+      - run: ruff check services/bot services/guardian
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [bot, guardian]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+        working-directory: services/${{ matrix.service }}
+      - run: python -m pytest tests/ -v
+        working-directory: services/${{ matrix.service }}
+
+  compose-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cp deploy/.env.example deploy/.env
+      - run: docker compose -f deploy/docker-compose.yml --env-file deploy/.env config -q
+
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [bot, guardian, lavalink]
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build services/${{ matrix.service }}


### PR DESCRIPTION
## What

- `.github/workflows/ci.yml`: four jobs on every PR and master push — ruff (pinned 0.15.20), pytest matrix (bot + guardian), compose config validation, Docker image builds (all 3 services)
- PR template enforcing test evidence + runbook-update discipline; feature/bug/ops-incident issue templates wired to the repo labels

## Why

Closes #21. Plan Tasks 8–9. Red CI blocks merge from here on. **Stacked on #25** (needs the services + compose files it validates).

## Test evidence

- Every CI command verified locally: ruff `All checks passed!`, bot 4 passed, guardian 4 passed, compose config exit 0, YAML parses
- This PR itself is the first live CI run — check the checks tab
- Two-stage subagent review: spec ✅ (line-by-line, plus verification that each job can succeed against the branch layout); quality ✅ approved with ruff pin applied

## Checklist

- [x] No secrets in the diff
- [x] Legacy code untouched; CI deliberately scopes to `services/` only in M1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a CI workflow for linting, testing, compose validation, and Docker builds, and standardize contribution templates for PRs and issues.

CI:
- Add GitHub Actions CI workflow running ruff linting, pytest for bot and guardian services, Docker Compose config validation, and Docker image builds for all services.

Documentation:
- Add a structured pull request template enforcing test evidence, documentation, and runbook updates.
- Add issue templates for ops incidents, bugs, and features wired to appropriate repository labels.