### PR TITLE
M1: docs pack — architecture, ADRs, operator runbook, deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,21 +3,19 @@
 ## Project: Jacky Music (Discord Music Bot)
 
 ### Repository Structure
-- `bot/` — Python Discord bot (discord.py + wavelink)
-- `frontend/` — React + Vite + TypeScript web app
-- `functions/` — Firebase Cloud Functions (YouTube search proxy)
-- `lavalink/` — Lavalink server configuration
+- `services/bot/` — Python Discord bot v2 (`src/jacky/`) — ACTIVE DEVELOPMENT
+- `services/guardian/` — supervisor: probe/classify/act/alert
+- `services/lavalink/` — templated Lavalink config
+- `deploy/` — docker-compose.yml + .env contract
+- `docs/` — architecture, ADRs, runbook, deployment, roadmap
+- `bot/` — LEGACY v1 bot (production until M5 cutover; no new features)
+- `frontend/`, `functions/` — unchanged (web app + search proxy)
 
-### Commands
-
-#### Bot
-```bash
-cd bot
-python -m venv .venv
-source .venv/bin/activate  # or .venv\Scripts\activate on Windows
-pip install -r requirements.txt
-python main.py
-```
+### Commands (v2)
+- `make help` — list everything
+- `make test` / `make lint` — pytest + ruff over services/
+- `make up` / `make logs s=<svc>` / `make restart s=<svc>` — stack ops
+- Spec: `docs/superpowers/specs/2026-07-02-stability-rewrite-design.md`
 
 #### Frontend
 ```bash
@@ -36,11 +34,6 @@ npm run build
 firebase deploy --only functions
 ```
 
-#### Docker (bot + Lavalink)
-```bash
-docker compose up -d --build
-```
-
 ### Architecture
 - Firestore is the single source of truth for playlist state
 - Bot and web app both read/write the same Firestore documents
@@ -53,8 +46,8 @@ docker compose up -d --build
 `@/*` maps to `src/*` in the frontend.
 
 ### Environment Variables
-See `.env.example` for all required variables.
+v2 stack: see `deploy/.env.example` (every variable documented inline).
+Legacy v1 bot: see root `.env.example`.
 
 ### Design & Plan
-- Design spec: `docs/superpowers/specs/2026-04-06-jacky-music-design.md`
-- Implementation plan: `docs/superpowers/plans/2026-04-06-jacky-music-implementation.md`
+- Design spec: `docs/superpowers/specs/2026-07-02-stability-rewrite-design.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Repository Structure
 - `services/bot/` — Python Discord bot v2 (`src/jacky/`) — ACTIVE DEVELOPMENT
-- `services/guardian/` — supervisor: probe/classify/act/alert
+- `services/guardian/` — supervisor (M1 skeleton; probe/classify/act/alert land in M4)
 - `services/lavalink/` — templated Lavalink config
 - `deploy/` — docker-compose.yml + .env contract
 - `docs/` — architecture, ADRs, runbook, deployment, roadmap

--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 Discord music bot with a companion web dashboard for real-time playlist management. Users control playback from Discord or the web app — both stay in sync via Firestore.
 
-## Architecture
+## Architecture (v2 — stability rewrite in progress)
 
-```
-Discord User ──> Bot (discord.py + wavelink) ──> Lavalink (audio) ──> Discord Voice
-                       │                              │
-                       ▼                              │
-                   Firestore  <───────────────────────┘
-                       ▲
-                       │
-Web User ──────> React Web App (Firebase Hosting)
-```
+Four crash-only Docker services on one VM; state lives in Firestore + a
+token volume, so any container can be restarted at any time.
 
-| Layer | Technology |
-|-------|-----------|
-| Bot | Python 3.11, discord.py 2.4.0, wavelink 3.4.1 |
-| Audio | Lavalink v4 (self-hosted, YouTube plugin) |
-| Web App | React 19, Vite 8, TypeScript 6, Tailwind CSS 4 |
-| Database | Firebase Firestore (real-time sync) |
-| Auth | Firebase Auth (Google sign-in for server activation) |
-| Functions | Firebase Cloud Functions (YouTube search proxy) |
-| Hosting | Firebase Hosting (web app), GCP e2-small VM (bot + Lavalink) |
+| Service | Role |
+|---------|------|
+| `services/bot` | Discord commands, voice, playback (stateless) |
+| `services/lavalink` | Audio engine (templated config, layered YouTube auth) |
+| `services/token-minter` | Scheduled poToken mint (M2) |
+| `services/guardian` | Canary probe → classify (F1–F9) → restart/alert |
+
+Docs: [Architecture](docs/architecture/ARCHITECTURE.md) ·
+[Runbook](docs/operations/RUNBOOK.md) ·
+[Deployment](docs/operations/DEPLOYMENT.md) ·
+[Decisions](docs/architecture/decisions/) ·
+[Roadmap](docs/roadmap/FUTURE.md)
+
+Quickstart: `cp deploy/.env.example deploy/.env`, fill it, `make up`.
+All commands: `make help`.
+
+> Legacy `bot/` + root `docker-compose.yml` remain in production until the
+> M5 cutover; do not add features there.
 
 ## Prerequisites
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -18,6 +18,6 @@ LAVALINK_HEAP=512m
 # Latest releases: https://github.com/lavalink-devs/youtube-source/releases
 YOUTUBE_PLUGIN_VERSION=1.18.1
 
-# OAuth refresh token (playbook F2). Obtain/rotate with: make reauth
+# OAuth refresh token (playbook F2). Obtain/rotate: make reauth (drives legacy stack until M2 — see RUNBOOK F2 caveat)
 # May be empty; poToken layer (M2) carries playback without it.
 YOUTUBE_OAUTH_REFRESH_TOKEN=

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Architecture
+
+> Living document. Derived from the approved design spec
+> (`docs/superpowers/specs/2026-07-02-stability-rewrite-design.md`);
+> update THIS file as the system evolves — the spec stays frozen.
+
+## Governing principle: crash-only
+
+Every container may be killed at any instant; the system converges back to
+correct state because durable state lives outside containers (Firestore +
+token volume). Recovery is always "restart," never choreography.
+
+## System overview
+
+One VM, four Docker Compose services. State lives outside containers: Firestore (queues, player state, guild config) and a named volume (tokens).
+
+```
+                        Discord                    YouTube
+                           ▲                          ▲
+                           │ gateway/voice            │ (poToken + OAuth + client-order)
+┌──────────────────────────┼──────────────────────────┼─────────────────────┐
+│ VM · Docker Compose      │                          │                     │
+│                      ┌───┴───┐   REST/WS      ┌─────┴─────┐               │
+│                      │  bot  ├───────────────►│ lavalink  │               │
+│                      └───┬───┘                └─▲───────▲─┘               │
+│                          │ health ping          │       │ poToken push    │
+│                      ┌───▼───────┐ canary lookup│  ┌────┴─────────┐       │
+│                      │ guardian  ├──────────────┘  │ token-minter │       │
+│                      └───┬───────┘                 │ (scheduled   │       │
+│                          │ restart / alert         │  one-shot)   │       │
+│                          ▼                         └──────────────┘       │
+│                    Docker API + Discord webhook                           │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+### `bot` (Python 3.11, discord.py)
+
+- Discord slash commands, voice connection, playback orchestration. Continues to honor the existing Firestore command documents written by the web dashboard.
+- Talks to Lavalink through a **thin owned client** (~300–400 lines: REST for track loading, WebSocket for events) replacing wavelink. We own reconnect behavior; no monkey-patching.
+- **Stateless:** on startup, rebuilds all player state from Firestore and re-attaches to Lavalink's session (Lavalink v4 session resuming lets a restarted bot adopt still-playing players).
+- Contains **zero** watchdog/recovery code — that is the guardian's job.
+- All node access goes through a `NodeProvider` interface. v1 ships one implementation (the VM's Lavalink). The future local-node feature is a second implementation with automatic fallback to the VM node when a local node disconnects — no rewrite required.
+
+### `lavalink` (Lavalink v4 + youtube-source plugin)
+
+- The audio engine. Client order tuned for datacenter IPs (`MUSIC` search-only, `TVHTML5_SIMPLY` first for playback, then `WEB`, `WEBEMBEDDED`, `ANDROID_VR`, `TV` carrying OAuth).
+- The plugin version is declared in **exactly one place** (`.env`) and templated into `application.yml` at container start (`application.yml.tmpl` + `entrypoint.sh`), making version drift structurally impossible.
+- OAuth refresh token supplied via env var.
+
+### `token-minter` (scheduled one-shot)
+
+- Every ~6 hours: starts, runs headless Chromium against YouTube (trusted-session-generator approach), harvests fresh `poToken` + `visitorData`, pushes them to Lavalink **at runtime** via the youtube-source plugin's REST endpoint (no restart), writes them to the shared volume for cold starts, exits.
+- No Google account involved → nothing revocable. Independent of the OAuth layer.
+
+### `guardian` (Python service, ~400 lines)
+
+The supervisor, outside every failure domain it watches. Four duties, one module each:
+
+1. **Probe** — every 2 min: a canary track lookup against Lavalink REST + a health ping to the bot; also compares Lavalink player position between probes when state says "playing" (frozen-position = silent failure).
+2. **Classify** — maps failure signatures to playbook IDs F1–F9 (see the [Runbook](../operations/RUNBOOK.md)).
+3. **Act** — restarts sick containers via the Docker socket; triggers an immediate token-minter run on poToken rejection.
+4. **Alert** — Discord webhook to the admin channel with the playbook ID, diagnosis, and exact fix command when a human is required. Daily youtube-source GitHub release check (drift warning before breakage). Weekly heartbeat message proving the alert channel itself works.
+
+## Data Flow
+
+**Playback (happy path):**
+1. `/play` (or a dashboard command doc) → bot resolves the request
+2. Bot asks Lavalink to load the track; youtube-source hits YouTube carrying poToken + OAuth + client ordering
+3. Bot writes queue/player state to **Firestore first**, then instructs Lavalink to play — Firestore is the source of truth; containers hold only caches
+4. Track-end events arrive over the owned WebSocket → bot pops the next track from Firestore
+
+**Recovery (any container dies):**
+- `bot` restarts → reads Firestore + re-attaches Lavalink session → converges; audio continues during the gap via session resuming
+- `lavalink` restarts → guardian detects; bot's client reconnects with backoff and re-issues "play at position X" from Firestore → seconds of gap, then resumes
+- `guardian` restarts → Docker `restart: unless-stopped`; it is stateless
+- `token-minter` fails → previous token remains valid (token validity windows overlap)

--- a/docs/architecture/decisions/0001-owned-lavalink-client.md
+++ b/docs/architecture/decisions/0001-owned-lavalink-client.md
@@ -1,0 +1,19 @@
+# ADR-0001: Own the Lavalink client instead of using wavelink
+
+**Status:** Accepted · 2026-07-02
+
+## Context
+wavelink required monkey-patching for Discord DAVE voice encryption, and its
+connection-state model obscured silent playback failures (Class B outages).
+Recovery behavior — the whole point of this rewrite — lived in a dependency
+we didn't control.
+
+## Decision
+Write a thin client (~300–400 lines: REST for loads, WebSocket for events)
+in `services/bot/src/jacky/audio/`. We own reconnect, backoff, and session
+resuming outright.
+
+## Consequences
+(+) Full control over failure behavior; no patching. (−) We maintain
+protocol code; mitigated by Lavalink v4's stable REST/WS API and tests
+against a fake WebSocket.

--- a/docs/architecture/decisions/0002-potoken-sidecar.md
+++ b/docs/architecture/decisions/0002-potoken-sidecar.md
@@ -1,0 +1,18 @@
+# ADR-0002: poToken sidecar as an independent auth layer
+
+**Status:** Accepted · 2026-07-02
+
+## Context
+The dominant outage class (F2): Google periodically revokes the OAuth
+refresh token, and recovery needed a human for days. Any single credential
+is a single point of failure.
+
+## Decision
+Run a scheduled one-shot container (token-minter) that mints a poToken +
+visitorData with headless Chromium and pushes them to Lavalink at runtime.
+No Google account involved — nothing to revoke. OAuth stays as the second,
+independent layer; client ordering as the third.
+
+## Consequences
+(+) OAuth revocation no longer stops playback; layers fail independently.
+(−) ~400MB RAM spike during each ~1-minute mint (fits budget: one-shot).

--- a/docs/architecture/decisions/0003-crash-only-state.md
+++ b/docs/architecture/decisions/0003-crash-only-state.md
@@ -1,0 +1,19 @@
+# ADR-0003: Crash-only containers; state externalized
+
+**Status:** Accepted · 2026-07-02
+
+## Context
+The old bot accreted 1,443 lines of interleaved playback + watchdog code
+because in-process recovery required delicate reconnect choreography.
+
+## Decision
+No container holds durable state. Firestore is the source of truth (written
+BEFORE Lavalink is instructed); tokens live on a named volume. The guardian's
+only recovery verb is "restart." Bot and guardian each carry a small
+duplicated runtime helper rather than sharing a library — 15 lines of
+duplication beats cross-service packaging coupling at this scale.
+
+## Consequences
+(+) Recovery logic is trivial and centralized in the guardian; bot code is
+pure playback. (−) Firestore write latency is on the command path (~50ms,
+acceptable for a music bot).

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -1,0 +1,22 @@
+# Deployment
+
+The deploy contract on ANY Linux host with Docker:
+`git clone` → `cp deploy/.env.example deploy/.env` (fill it) → `make up`.
+No cloud-specific dependencies.
+
+## Current host: GCP e2-small
+- Project `personal-server-492701`, instance `personal-project-machine`
+- SSH: `gcloud compute ssh personal-project-machine --project=personal-server-492701`
+- Update deploy: `make deploy` (pulls master, rebuilds, restarts changed services)
+
+## Planned host: Hetzner (~€4/mo, better YouTube IP reputation tier)
+Migration = the deploy contract above + repoint the external uptime monitor.
+
+## Secrets
+Live only in `deploy/.env` on the host (git-ignored). `.env.example`
+documents every variable. Rotate `LAVALINK_PASSWORD` freely: `make up`
+re-propagates it to all services.
+
+## External uptime monitor (playbook F7)
+The VM cannot report its own death. A free-tier monitor (e.g. UptimeRobot)
+pings the guardian's heartbeat endpoint (M4) and emails/DMs on silence.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -1,0 +1,167 @@
+# Operator Runbook
+
+Guardian alerts carry a playbook ID (F1–F9). Find the ID below; run exactly
+what it says. All commands run on the VM from the repo root.
+
+> **Status:** Playbook IDs and automated responses land with M2 (token-minter)
+> and M4 (guardian). Until then, use the Confirm/Fix commands manually.
+
+## Playbook index
+
+| ID | Failure | Detected by | Automated response | Human needed? |
+|----|---------|-------------|--------------------|---------------|
+| F1 | poToken stale/rejected | Canary: bot-detection error | Trigger token-minter immediately, re-probe | No |
+| F2 | OAuth token revoked | Canary: "requires login" + OAuth 400 | Alert with one-command re-auth (`make reauth`) | **Yes** (~60s device flow) |
+| F3 | Plugin broken by YouTube JS change | Canary: signature/cipher errors | Alert with exact version bump; release watcher usually warns first | Yes (approve bump) |
+| F4 | Lavalink sick/dead | Canary timeout / Docker health | Guardian restarts container; bot reconnects + restores from Firestore | No |
+| F5 | Bot hung (gateway zombie) | Guardian's bot health ping | Guardian restarts bot container | No |
+| F6 | Silent playback (position frozen) | Position comparison across probes | Restart playback via bot; escalate to container restart on repeat | No |
+| F7 | VM down / Docker dead | External uptime monitor (free tier) pinging guardian's heartbeat URL | External email/DM | Yes |
+| F8 | Firestore unreachable | Bot + guardian error rates | Continue from in-memory cache; queue writes, flush on recovery; alert if sustained | No |
+| F9 | Alert channel broken | Weekly guardian heartbeat message | — | Missing heartbeat noticed by operator |
+
+## F1 — poToken stale or rejected
+
+**Alert looks like:** `[F1] poToken rejected — canary load hit YouTube bot
+detection. Triggered token-minter; re-probing in 2 min.`
+
+**Confirm:** `make logs s=lavalink | grep -i "sign in to confirm"` shows
+bot-detection errors on track loads.
+
+**Fix:** normally none — the guardian triggers an immediate token-minter run
+(M2) and re-probes. If the alert repeats:
+1. `make restart s=lavalink` — reload tokens from the shared volume
+2. Verify: play a test track, or `make logs s=guardian` shows the canary passing
+
+**While pending:** the OAuth layer (F2) and client ordering keep most
+playback working; only bot-detection-gated loads fail.
+
+## F2 — YouTube OAuth token revoked
+
+**Alert looks like:** `[F2] OAuth revoked — all loads failing with "requires
+login". Run: make reauth`
+
+**Confirm:** `make logs s=lavalink | grep -i oauth` shows
+`Invalid status code for oauth2 token fetch: 400` repeating.
+
+**Fix (~60s):**
+1. `make reauth` — prints a device code and URL (google.com/device)
+2. Open the URL on any machine, enter the code, approve with the bot's Google account
+3. The script writes the new token to `deploy/.env` and restarts Lavalink
+4. Verify: guardian posts `[F2 resolved]` after its next probe (≤2 min)
+
+**While pending:** poToken layer (F1) keeps most tracks playing; only
+sign-in-gated tracks fail.
+
+## F3 — youtube-source plugin broken by a YouTube JS change
+
+**Alert looks like:** `[F3] Signature extraction failing — youtube-source
+vX.Y.Z is stale. Bump YOUTUBE_PLUGIN_VERSION in deploy/.env and restart
+lavalink.` (The daily release watcher usually warns before breakage.)
+
+**Confirm:** `make logs s=lavalink | grep -iE "cipher|signature"` shows
+extraction/decipher errors on every load.
+
+**Fix (~2 min):**
+1. Find the latest release at github.com/lavalink-devs/youtube-source/releases
+2. Edit `YOUTUBE_PLUGIN_VERSION` in `deploy/.env` (the only place the version lives)
+3. `make restart s=lavalink` — the entrypoint re-renders `application.yml` from the template, so config and jar cannot drift
+4. Verify: play a test track; canary passes on the next probe
+
+**While pending:** all YouTube loads fail; no auth layer helps against a
+signature break. This is the highest-urgency human playbook.
+
+## F4 — Lavalink sick or dead
+
+**Alert looks like:** `[F4] Lavalink unresponsive (canary timeout) —
+restarting container.`
+
+**Confirm:** `make ps` shows `lavalink` unhealthy or restarting;
+`make logs s=lavalink` shows a crash, OOM kill, or startup failure.
+
+**Fix:** automated — the guardian restarts the container; the bot's client
+reconnects with backoff and re-issues "play at position X" from Firestore
+(seconds of gap). Manually:
+1. `make restart s=lavalink`
+2. Verify: `make ps` shows healthy; playback resumes
+
+**If it crash-loops:** check memory pressure (`docker stats`) — Lavalink's
+budget is ~800MB RSS on the 2GB VM — and inspect `make logs s=lavalink`
+for a config error before restarting again.
+
+## F5 — Bot hung (gateway zombie)
+
+**Alert looks like:** `[F5] Bot health ping timed out — restarting bot
+container.`
+
+**Confirm:** `make logs s=bot` shows no recent gateway activity or repeating
+heartbeat/resume failures; bot appears online in Discord but ignores commands.
+
+**Fix:** automated — the guardian restarts the bot container. Manually:
+1. `make restart s=bot`
+2. The bot is stateless: it rebuilds player state from Firestore and re-attaches to Lavalink's session (audio continues during the gap)
+3. Verify: bot responds to a command; guardian's next bot ping passes
+
+## F6 — Silent playback (position frozen)
+
+**Alert looks like:** `[F6] Player position frozen across probes while state
+says playing — restarting playback.`
+
+**Confirm:** Discord shows "now playing" but no audio; `make logs s=guardian`
+shows the position comparison failing between probes.
+
+**Fix:** automated — the guardian restarts playback via the bot, escalating
+to a container restart on repeat. Manually:
+1. Skip or replay the current track from Discord or the dashboard
+2. If still silent: `make restart s=lavalink`, then replay — the bot re-issues "play at position X" from Firestore
+3. Verify: position advances between the next two guardian probes
+
+## F7 — VM down / Docker dead
+
+**Alert looks like:** an email/DM from the **external uptime monitor** (not
+the guardian — the VM cannot report its own death): "guardian heartbeat URL
+unreachable".
+
+**Confirm:**
+`gcloud compute ssh personal-project-machine --project=personal-server-492701`
+— if SSH fails, check the instance in the GCP console.
+
+**Fix:**
+1. Start (or reset) the instance from the GCP console if it is stopped/wedged
+2. SSH in; if Docker died but the VM is up: `sudo systemctl restart docker`
+3. From the repo root: `make up` — every service is crash-only, so a cold start converges on its own
+4. Verify: `make ps` all healthy; uptime monitor reports the heartbeat URL reachable
+
+## F8 — Firestore unreachable
+
+**Alert looks like:** `[F8] Firestore error rate sustained for >5 min —
+serving from cache, queueing writes.`
+
+**Confirm:** `make logs s=bot | grep -i firestore` shows
+UNAVAILABLE/deadline-exceeded errors; check status.cloud.google.com for a
+Firestore incident.
+
+**Fix:** normally none — the bot continues from its in-memory cache and
+flushes queued writes when Firestore recovers. If sustained beyond a GCP
+incident window:
+1. Verify the service-account credentials referenced in `deploy/.env` are valid
+2. `make restart s=bot` after connectivity returns to force a clean state rebuild
+3. Verify: writes flush and the alert clears on the next probe
+
+**Impact while pending:** playback continues; dashboard sync and queue
+persistence lag until writes flush.
+
+## F9 — Alert channel broken
+
+**Alert looks like:** nothing — that is the failure. The guardian posts a
+weekly heartbeat message; its **absence** is the signal (calendar reminder
+recommended).
+
+**Confirm:** `make logs s=guardian | grep -i webhook` shows delivery errors
+(HTTP 4xx — webhook deleted or channel removed).
+
+**Fix:**
+1. Re-create the webhook in the Discord admin channel (Server Settings → Integrations → Webhooks)
+2. Update `ALERT_WEBHOOK_URL` in `deploy/.env`
+3. `make restart s=guardian`
+4. Verify: guardian posts its startup/heartbeat message to the channel

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -3,8 +3,14 @@
 Guardian alerts carry a playbook ID (F1–F9). Find the ID below; run exactly
 what it says. All commands run on the VM from the repo root.
 
-> **Status:** Playbook IDs and automated responses land with M2 (token-minter)
-> and M4 (guardian). Until then, use the Confirm/Fix commands manually.
+> **Status:** Playbook IDs and automated responses land with M2 (token-minter),
+> M3 (bot playback/state), and M4 (guardian). Until then, use the Confirm/Fix
+> commands manually.
+
+> **Reading logs:** `make logs s=<svc>` follows live output (Ctrl-C to exit;
+> silence after a few seconds means no match) and starts from the last 100
+> lines. To search further back without following:
+> `docker compose -f deploy/docker-compose.yml --env-file deploy/.env logs --tail=1000 <svc> | grep -i <pattern>`
 
 ## Playbook index
 
@@ -30,13 +36,18 @@ bot-detection errors on track loads.
 
 **Fix:** normally none — the guardian triggers an immediate token-minter run
 (M2) and re-probes. If the alert repeats:
-1. `make restart s=lavalink` — reload tokens from the shared volume
+1. `make restart s=lavalink` — reload tokens from the shared volume (effective from M2 — the volume is unread until token-minter lands)
 2. Verify: play a test track, or `make logs s=guardian` shows the canary passing
 
 **While pending:** the OAuth layer (F2) and client ordering keep most
 playback working; only bot-detection-gated loads fail.
 
 ## F2 — YouTube OAuth token revoked
+
+> **M1 caveat:** `make reauth` currently drives the LEGACY stack's script. For
+> the v2 stack, after completing the device flow, manually copy the printed
+> refresh token into `deploy/.env` (`YOUTUBE_OAUTH_REFRESH_TOKEN=...`) and run
+> `make restart s=lavalink`. The v2-native flow lands in M2.
 
 **Alert looks like:** `[F2] OAuth revoked — all loads failing with "requires
 login". Run: make reauth`
@@ -47,7 +58,7 @@ login". Run: make reauth`
 **Fix (~60s):**
 1. `make reauth` — prints a device code and URL (google.com/device)
 2. Open the URL on any machine, enter the code, approve with the bot's Google account
-3. The script writes the new token to `deploy/.env` and restarts Lavalink
+3. The script writes the new token to the legacy stack's root `.env` and restarts the legacy Lavalink container — for the v2 stack, apply the token manually per the caveat above
 4. Verify: guardian posts `[F2 resolved]` after its next probe (≤2 min)
 
 **While pending:** poToken layer (F1) keeps most tracks playing; only
@@ -76,7 +87,7 @@ signature break. This is the highest-urgency human playbook.
 **Alert looks like:** `[F4] Lavalink unresponsive (canary timeout) —
 restarting container.`
 
-**Confirm:** `make ps` shows `lavalink` unhealthy or restarting;
+**Confirm:** `make ps` shows `lavalink` restarting or exited;
 `make logs s=lavalink` shows a crash, OOM kill, or startup failure.
 
 **Fix:** automated — the guardian restarts the container; the bot's client
@@ -142,11 +153,10 @@ UNAVAILABLE/deadline-exceeded errors; check status.cloud.google.com for a
 Firestore incident.
 
 **Fix:** normally none — the bot continues from its in-memory cache and
-flushes queued writes when Firestore recovers. If sustained beyond a GCP
-incident window:
-1. Verify the service-account credentials referenced in `deploy/.env` are valid
-2. `make restart s=bot` after connectivity returns to force a clean state rebuild
-3. Verify: writes flush and the alert clears on the next probe
+flushes queued writes when Firestore recovers (lands with the M3 bot). If
+sustained beyond a GCP incident window:
+1. `make restart s=bot` after connectivity returns to force a clean state rebuild
+2. Verify: writes flush and the alert clears on the next probe
 
 **Impact while pending:** playback continues; dashboard sync and queue
 persistence lag until writes flush.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -44,10 +44,12 @@ playback working; only bot-detection-gated loads fail.
 
 ## F2 — YouTube OAuth token revoked
 
-> **M1 caveat:** `make reauth` currently drives the LEGACY stack's script. For
-> the v2 stack, after completing the device flow, manually copy the printed
-> refresh token into `deploy/.env` (`YOUTUBE_OAUTH_REFRESH_TOKEN=...`) and run
-> `make restart s=lavalink`. The v2-native flow lands in M2.
+> **M1 caveat:** `make reauth` currently drives the LEGACY stack's script,
+> which writes the token silently to the root `.env` (it is never printed to
+> the terminal). For the v2 stack: after completing the device flow, copy
+> `YOUTUBE_OAUTH_REFRESH_TOKEN` from the root `.env` into `deploy/.env`, then
+> run `make up` (a plain restart does NOT re-read env changes — the container
+> must be recreated). The v2-native flow lands in M2.
 
 **Alert looks like:** `[F2] OAuth revoked — all loads failing with "requires
 login". Run: make reauth`

--- a/docs/roadmap/FUTURE.md
+++ b/docs/roadmap/FUTURE.md
@@ -1,0 +1,6 @@
+# Roadmap (deferred — brainstorm before building)
+
+1. **Local audio nodes** — user-hosted Lavalink for low latency; `NodeProvider` second implementation with automatic fallback to the VM node on local-node disconnect.
+2. **Dashboard "summon"** — logged-in users click a previously-visited voice channel in the web UI to make the bot join it (within allowed guilds).
+3. **Search engine fix** — playlist URL → the URL's track plus the playlist's tracks as results; single-video URL → normal search with similar recommendations.
+4. **Spotify support.**

--- a/services/bot/README.md
+++ b/services/bot/README.md
@@ -3,6 +3,8 @@
 **What:** Discord-facing service — slash commands, voice, playback
 orchestration. Zero recovery logic (guardian's job, ADR-0003).
 
+**Status:** M1 skeleton — only `core/` exists; `commands/`, `audio/`, `state/` land in M3.
+
 **Run:** `pip install -e ".[dev]" && python -m jacky` · Tests: `pytest`
 
 **Depends on:** Lavalink (REST/WS, env: LAVALINK_HOST/PORT/PASSWORD),

--- a/services/bot/README.md
+++ b/services/bot/README.md
@@ -1,0 +1,11 @@
+# jacky-bot
+
+**What:** Discord-facing service — slash commands, voice, playback
+orchestration. Zero recovery logic (guardian's job, ADR-0003).
+
+**Run:** `pip install -e ".[dev]" && python -m jacky` · Tests: `pytest`
+
+**Depends on:** Lavalink (REST/WS, env: LAVALINK_HOST/PORT/PASSWORD),
+Firestore (source of truth), Discord gateway (DISCORD_TOKEN).
+Layout: `commands/` Discord handlers · `audio/` owned Lavalink client +
+NodeProvider · `state/` Firestore repositories · `core/` config/lifecycle.

--- a/services/guardian/README.md
+++ b/services/guardian/README.md
@@ -1,0 +1,11 @@
+# jacky-guardian
+
+**What:** The supervisor. Probes (canary track lookup + bot ping every
+2 min), classifies failures to playbook IDs F1–F9, restarts sick containers
+(Docker socket), alerts via Discord webhook with the exact fix.
+
+**Run:** `pip install -e ".[dev]" && python -m guardian` · Tests: `pytest`
+
+**Depends on:** Lavalink REST, bot health endpoint, Docker socket
+(mounted), ALERT_WEBHOOK_URL. One module per duty: `probe` / `classify` /
+`act` / `alert`.

--- a/services/guardian/README.md
+++ b/services/guardian/README.md
@@ -4,6 +4,8 @@
 2 min), classifies failures to playbook IDs F1–F9, restarts sick containers
 (Docker socket), alerts via Discord webhook with the exact fix.
 
+**Status:** M1 skeleton — runtime shell only; probe/classify/act/alert land in M4.
+
 **Run:** `pip install -e ".[dev]" && python -m guardian` · Tests: `pytest`
 
 **Depends on:** Lavalink REST, bot health endpoint, Docker socket

--- a/services/lavalink/README.md
+++ b/services/lavalink/README.md
@@ -2,6 +2,8 @@
 
 **What:** Lavalink v4 + youtube-source plugin — the audio engine.
 
+**Status:** Active from M1 — poToken volume input becomes live in M2.
+
 **Config:** `application.yml.tmpl` rendered at container start; the plugin
 version comes ONLY from `.env` (`YOUTUBE_PLUGIN_VERSION`) so config/jar
 drift is impossible. Secrets resolve via Spring env placeholders — never

--- a/services/lavalink/README.md
+++ b/services/lavalink/README.md
@@ -1,0 +1,11 @@
+# lavalink
+
+**What:** Lavalink v4 + youtube-source plugin — the audio engine.
+
+**Config:** `application.yml.tmpl` rendered at container start; the plugin
+version comes ONLY from `.env` (`YOUTUBE_PLUGIN_VERSION`) so config/jar
+drift is impossible. Secrets resolve via Spring env placeholders — never
+written to disk.
+
+**Depends on:** YouTube (poToken via token-minter volume + OAuth env +
+client ordering — see ADR-0002).


### PR DESCRIPTION
## What

- `docs/architecture/ARCHITECTURE.md` — living architecture doc (spec §3–4 carried over; spec stays frozen)
- `docs/architecture/decisions/` — ADRs 0001 (owned Lavalink client), 0002 (poToken sidecar), 0003 (crash-only state)
- `docs/operations/RUNBOOK.md` — the F1–F9 failure playbook as a 3am operator manual: literal alert strings, copy-pasteable Confirm commands, numbered fixes, honest now-vs-designed tags (M2/M3/M4)
- `docs/operations/DEPLOYMENT.md`, `docs/roadmap/FUTURE.md`, service READMEs with status markers
- `README.md` + `CLAUDE.md` repointed at the v2 structure

## Why

Closes #22. Plan Tasks 10–11. **Stacked on #26** — merge order: #24 → #25 → #26 → this.

## Test evidence

- Every operational claim verified against the actual Makefile/compose/scripts by reviewer subagents (spec review confirmed §3/§4/§5/§10 carried byte-identical where required)
- All relative links checked — zero broken
- Quality review caught and we fixed: F2's reauth steps misdirecting operators to the legacy stack, follow-mode log pipelines, and present-tense descriptions of not-yet-built components

## Checklist

- [x] RUNBOOK reflects real failure/recovery behavior (with M-milestone tags where designed-not-built)
- [x] No secrets in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the new v2 crash-only architecture, operational model, and deployment contract, and repoint top-level docs to the new structure.

Enhancements:
- Update top-level README and CLAUDE.md to reflect the v2 architecture, repo layout, and make-based workflows.

Documentation:
- Add a living architecture document describing the crash-only v2 stack, services, and data flows.
- Introduce ADRs for owning the Lavalink client, poToken sidecar auth, and crash-only state externalization.
- Add an operator runbook with F1–F9 failure playbooks and concrete confirm/fix steps.
- Document deployment procedures, environments, and secret handling for the v2 stack.
- Add a future roadmap outlining deferred features and improvements.
- Add service-level READMEs for bot, guardian, and Lavalink describing roles, status, and dependencies.