### PR TITLE
M1: consolidate deploy/CI/docs stack onto master + Linux signal fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,15 @@
+---
+name: Bug
+about: Something is broken
+labels: type:bug
+---
+
+## Observed
+
+## Expected
+
+## Playbook ID (if from a guardian alert)
+
+<!-- F1-F9, see docs/operations/RUNBOOK.md -->
+
+## Logs / evidence

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,15 @@
+---
+name: Feature
+about: A unit of planned work
+labels: type:feature
+---
+
+## Goal
+
+## Acceptance criteria
+
+- [ ]
+
+## Plan reference
+
+<!-- e.g. docs/superpowers/plans/2026-07-02-stability-rewrite-m1-foundation.md Task N -->

--- a/.github/ISSUE_TEMPLATE/ops-incident.md
+++ b/.github/ISSUE_TEMPLATE/ops-incident.md
@@ -1,0 +1,17 @@
+---
+name: Ops incident
+about: Production outage or degradation post-mortem
+labels: type:ops
+---
+
+## Timeline
+
+## Playbook ID + was detection automatic?
+
+## Root cause
+
+## What would have prevented it
+
+## Follow-up actions
+
+- [ ]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What
+
+<!-- One paragraph: what this PR does -->
+
+## Why
+
+<!-- Link the issue: Closes #N -->
+
+## Test evidence
+
+<!-- Paste test run output or describe manual verification -->
+
+## Checklist
+
+- [ ] CI green
+- [ ] Docs updated (service README / ARCHITECTURE.md) if behavior changed
+- [ ] RUNBOOK.md updated if failure/recovery behavior changed
+- [ ] No secrets in the diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install ruff
+      # Pinned: red CI blocks merge, so lint rules may only change via a deliberate bump
+      - run: pip install "ruff==0.15.20"
       - run: ruff check services/bot services/guardian
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install ruff
+      - run: ruff check services/bot services/guardian
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [bot, guardian]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+        working-directory: services/${{ matrix.service }}
+      - run: python -m pytest tests/ -v
+        working-directory: services/${{ matrix.service }}
+
+  compose-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cp deploy/.env.example deploy/.env
+      - run: docker compose -f deploy/docker-compose.yml --env-file deploy/.env config -q
+
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [bot, guardian, lavalink]
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build services/${{ matrix.service }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,21 +3,19 @@
 ## Project: Jacky Music (Discord Music Bot)
 
 ### Repository Structure
-- `bot/` — Python Discord bot (discord.py + wavelink)
-- `frontend/` — React + Vite + TypeScript web app
-- `functions/` — Firebase Cloud Functions (YouTube search proxy)
-- `lavalink/` — Lavalink server configuration
+- `services/bot/` — Python Discord bot v2 (`src/jacky/`) — ACTIVE DEVELOPMENT
+- `services/guardian/` — supervisor: probe/classify/act/alert
+- `services/lavalink/` — templated Lavalink config
+- `deploy/` — docker-compose.yml + .env contract
+- `docs/` — architecture, ADRs, runbook, deployment, roadmap
+- `bot/` — LEGACY v1 bot (production until M5 cutover; no new features)
+- `frontend/`, `functions/` — unchanged (web app + search proxy)
 
-### Commands
-
-#### Bot
-```bash
-cd bot
-python -m venv .venv
-source .venv/bin/activate  # or .venv\Scripts\activate on Windows
-pip install -r requirements.txt
-python main.py
-```
+### Commands (v2)
+- `make help` — list everything
+- `make test` / `make lint` — pytest + ruff over services/
+- `make up` / `make logs s=<svc>` / `make restart s=<svc>` — stack ops
+- Spec: `docs/superpowers/specs/2026-07-02-stability-rewrite-design.md`
 
 #### Frontend
 ```bash
@@ -36,11 +34,6 @@ npm run build
 firebase deploy --only functions
 ```
 
-#### Docker (bot + Lavalink)
-```bash
-docker compose up -d --build
-```
-
 ### Architecture
 - Firestore is the single source of truth for playlist state
 - Bot and web app both read/write the same Firestore documents
@@ -53,8 +46,8 @@ docker compose up -d --build
 `@/*` maps to `src/*` in the frontend.
 
 ### Environment Variables
-See `.env.example` for all required variables.
+v2 stack: see `deploy/.env.example` (every variable documented inline).
+Legacy v1 bot: see root `.env.example`.
 
 ### Design & Plan
-- Design spec: `docs/superpowers/specs/2026-04-06-jacky-music-design.md`
-- Implementation plan: `docs/superpowers/plans/2026-04-06-jacky-music-implementation.md`
+- Design spec: `docs/superpowers/specs/2026-07-02-stability-rewrite-design.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ### Repository Structure
 - `services/bot/` — Python Discord bot v2 (`src/jacky/`) — ACTIVE DEVELOPMENT
-- `services/guardian/` — supervisor: probe/classify/act/alert
+- `services/guardian/` — supervisor (M1 skeleton; probe/classify/act/alert land in M4)
 - `services/lavalink/` — templated Lavalink config
 - `deploy/` — docker-compose.yml + .env contract
 - `docs/` — architecture, ADRs, runbook, deployment, roadmap

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,5 @@ build: ## Build all images without starting
 deploy: ## Production deploy (run on the VM)
 	git pull origin master && $(COMPOSE) up -d --build
 
-reauth: ## Re-run YouTube OAuth device flow (playbook F2)
+reauth: ## YouTube OAuth device flow (legacy stack script; v2 flow lands in M2)
 	./scripts/reauth-youtube.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+COMPOSE := docker compose -f deploy/docker-compose.yml --env-file deploy/.env
+
+.PHONY: help up down restart logs ps test lint build deploy reauth
+
+help: ## List commands
+	@grep -E '^[a-z-]+:.*##' $(MAKEFILE_LIST) | awk -F':.*## ' '{printf "  make %-10s %s\n", $$1, $$2}'
+
+up: ## Start the stack
+	$(COMPOSE) up -d --build
+
+down: ## Stop the stack
+	$(COMPOSE) down
+
+restart: ## Restart one service: make restart s=lavalink
+	$(COMPOSE) restart $(s)
+
+logs: ## Tail logs (all, or one: make logs s=bot)
+	$(COMPOSE) logs -f --tail=100 $(s)
+
+ps: ## Show service status
+	$(COMPOSE) ps
+
+test: ## Run all unit tests
+	cd services/bot && python -m pytest tests/ -q
+	cd services/guardian && python -m pytest tests/ -q
+
+lint: ## Ruff over both services
+	ruff check services/bot services/guardian
+
+build: ## Build all images without starting
+	$(COMPOSE) build
+
+deploy: ## Production deploy (run on the VM)
+	git pull origin master && $(COMPOSE) up -d --build
+
+reauth: ## Re-run YouTube OAuth device flow (playbook F2)
+	./scripts/reauth-youtube.sh

--- a/README.md
+++ b/README.md
@@ -2,27 +2,29 @@
 
 Discord music bot with a companion web dashboard for real-time playlist management. Users control playback from Discord or the web app — both stay in sync via Firestore.
 
-## Architecture
+## Architecture (v2 — stability rewrite in progress)
 
-```
-Discord User ──> Bot (discord.py + wavelink) ──> Lavalink (audio) ──> Discord Voice
-                       │                              │
-                       ▼                              │
-                   Firestore  <───────────────────────┘
-                       ▲
-                       │
-Web User ──────> React Web App (Firebase Hosting)
-```
+Four crash-only Docker services on one VM; state lives in Firestore + a
+token volume, so any container can be restarted at any time.
 
-| Layer | Technology |
-|-------|-----------|
-| Bot | Python 3.11, discord.py 2.4.0, wavelink 3.4.1 |
-| Audio | Lavalink v4 (self-hosted, YouTube plugin) |
-| Web App | React 19, Vite 8, TypeScript 6, Tailwind CSS 4 |
-| Database | Firebase Firestore (real-time sync) |
-| Auth | Firebase Auth (Google sign-in for server activation) |
-| Functions | Firebase Cloud Functions (YouTube search proxy) |
-| Hosting | Firebase Hosting (web app), GCP e2-small VM (bot + Lavalink) |
+| Service | Role |
+|---------|------|
+| `services/bot` | Discord commands, voice, playback (stateless) |
+| `services/lavalink` | Audio engine (templated config, layered YouTube auth) |
+| `services/token-minter` | Scheduled poToken mint (M2) |
+| `services/guardian` | Canary probe → classify (F1–F9) → restart/alert |
+
+Docs: [Architecture](docs/architecture/ARCHITECTURE.md) ·
+[Runbook](docs/operations/RUNBOOK.md) ·
+[Deployment](docs/operations/DEPLOYMENT.md) ·
+[Decisions](docs/architecture/decisions/) ·
+[Roadmap](docs/roadmap/FUTURE.md)
+
+Quickstart: `cp deploy/.env.example deploy/.env`, fill it, `make up`.
+All commands: `make help`.
+
+> Legacy `bot/` + root `docker-compose.yml` remain in production until the
+> M5 cutover; do not add features there.
 
 ## Prerequisites
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -18,6 +18,6 @@ LAVALINK_HEAP=512m
 # Latest releases: https://github.com/lavalink-devs/youtube-source/releases
 YOUTUBE_PLUGIN_VERSION=1.18.1
 
-# OAuth refresh token (playbook F2). Obtain/rotate with: make reauth
+# OAuth refresh token (playbook F2). Obtain/rotate: make reauth (drives legacy stack until M2 — see RUNBOOK F2 caveat)
 # May be empty; poToken layer (M2) carries playback without it.
 YOUTUBE_OAUTH_REFRESH_TOKEN=

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,23 @@
+# ── Discord ──────────────────────────────────────────────────────────────
+# Bot token: Discord Developer Portal → your app → Bot → Token
+DISCORD_TOKEN=changeme
+
+# Discord webhook URL for guardian alerts (Server Settings → Integrations →
+# Webhooks → New Webhook in your admin channel)
+ALERT_WEBHOOK_URL=changeme
+
+# ── Lavalink ─────────────────────────────────────────────────────────────
+# Shared secret between bot/guardian and Lavalink. Generate: openssl rand -hex 16
+LAVALINK_PASSWORD=changeme
+
+# JVM heap. 512m fits the 2GB VM budget (see spec §2 constraints).
+LAVALINK_HEAP=512m
+
+# ── YouTube source ───────────────────────────────────────────────────────
+# THE ONLY PLACE the youtube-source plugin version is declared (spec §3.2).
+# Latest releases: https://github.com/lavalink-devs/youtube-source/releases
+YOUTUBE_PLUGIN_VERSION=1.18.1
+
+# OAuth refresh token (playbook F2). Obtain/rotate with: make reauth
+# May be empty; poToken layer (M2) carries playback without it.
+YOUTUBE_OAUTH_REFRESH_TOKEN=

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,52 @@
+name: jacky-music
+
+services:
+  lavalink:
+    build: ../services/lavalink
+    container_name: jacky-lavalink
+    restart: unless-stopped
+    environment:
+      _JAVA_OPTIONS: "-Xmx${LAVALINK_HEAP:-512m}"
+      LAVALINK_SERVER_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
+      YOUTUBE_PLUGIN_VERSION: ${YOUTUBE_PLUGIN_VERSION:?set in .env}
+      YOUTUBE_OAUTH_REFRESH_TOKEN: ${YOUTUBE_OAUTH_REFRESH_TOKEN:-}
+    expose:
+      - "2333"
+    volumes:
+      - tokens:/data/tokens:ro
+    networks: [jacky]
+
+  bot:
+    build: ../services/bot
+    container_name: jacky-bot
+    restart: unless-stopped
+    environment:
+      DISCORD_TOKEN: ${DISCORD_TOKEN:?set in .env}
+      LAVALINK_HOST: lavalink
+      LAVALINK_PORT: "2333"
+      LAVALINK_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
+    depends_on:
+      - lavalink
+    networks: [jacky]
+
+  guardian:
+    build: ../services/guardian
+    container_name: jacky-guardian
+    restart: unless-stopped
+    environment:
+      LAVALINK_HOST: lavalink
+      LAVALINK_PORT: "2333"
+      LAVALINK_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
+      ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:?set in .env}
+    volumes:
+      # Guardian's only privilege: restarting sibling containers (playbook F4/F5).
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - lavalink
+    networks: [jacky]
+
+networks:
+  jacky: {}
+
+volumes:
+  tokens: {}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,8 +3,14 @@ name: jacky-music
 services:
   lavalink:
     build: ../services/lavalink
-    container_name: jacky-lavalink
     restart: unless-stopped
+    # Rotation is load-bearing: a revoked OAuth token (playbook F2) makes the
+    # youtube plugin log errors every 5s; unbounded logs once filled the VM disk.
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       _JAVA_OPTIONS: "-Xmx${LAVALINK_HEAP:-512m}"
       LAVALINK_SERVER_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
@@ -18,8 +24,12 @@ services:
 
   bot:
     build: ../services/bot
-    container_name: jacky-bot
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       DISCORD_TOKEN: ${DISCORD_TOKEN:?set in .env}
       LAVALINK_HOST: lavalink
@@ -31,15 +41,20 @@ services:
 
   guardian:
     build: ../services/guardian
-    container_name: jacky-guardian
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
     environment:
       LAVALINK_HOST: lavalink
       LAVALINK_PORT: "2333"
       LAVALINK_PASSWORD: ${LAVALINK_PASSWORD:?set in .env}
       ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:?set in .env}
     volumes:
-      # Guardian's only privilege: restarting sibling containers (playbook F4/F5).
+      # Root-equivalent access to the host, accepted by design (spec §3.4):
+      # guardian uses it only to restart sibling services (playbook F4/F5).
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - lavalink

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# Architecture
+
+> Living document. Derived from the approved design spec
+> (`docs/superpowers/specs/2026-07-02-stability-rewrite-design.md`);
+> update THIS file as the system evolves — the spec stays frozen.
+
+## Governing principle: crash-only
+
+Every container may be killed at any instant; the system converges back to
+correct state because durable state lives outside containers (Firestore +
+token volume). Recovery is always "restart," never choreography.
+
+## System overview
+
+One VM, four Docker Compose services. State lives outside containers: Firestore (queues, player state, guild config) and a named volume (tokens).
+
+```
+                        Discord                    YouTube
+                           ▲                          ▲
+                           │ gateway/voice            │ (poToken + OAuth + client-order)
+┌──────────────────────────┼──────────────────────────┼─────────────────────┐
+│ VM · Docker Compose      │                          │                     │
+│                      ┌───┴───┐   REST/WS      ┌─────┴─────┐               │
+│                      │  bot  ├───────────────►│ lavalink  │               │
+│                      └───┬───┘                └─▲───────▲─┘               │
+│                          │ health ping          │       │ poToken push    │
+│                      ┌───▼───────┐ canary lookup│  ┌────┴─────────┐       │
+│                      │ guardian  ├──────────────┘  │ token-minter │       │
+│                      └───┬───────┘                 │ (scheduled   │       │
+│                          │ restart / alert         │  one-shot)   │       │
+│                          ▼                         └──────────────┘       │
+│                    Docker API + Discord webhook                           │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+### `bot` (Python 3.11, discord.py)
+
+- Discord slash commands, voice connection, playback orchestration. Continues to honor the existing Firestore command documents written by the web dashboard.
+- Talks to Lavalink through a **thin owned client** (~300–400 lines: REST for track loading, WebSocket for events) replacing wavelink. We own reconnect behavior; no monkey-patching.
+- **Stateless:** on startup, rebuilds all player state from Firestore and re-attaches to Lavalink's session (Lavalink v4 session resuming lets a restarted bot adopt still-playing players).
+- Contains **zero** watchdog/recovery code — that is the guardian's job.
+- All node access goes through a `NodeProvider` interface. v1 ships one implementation (the VM's Lavalink). The future local-node feature is a second implementation with automatic fallback to the VM node when a local node disconnects — no rewrite required.
+
+### `lavalink` (Lavalink v4 + youtube-source plugin)
+
+- The audio engine. Client order tuned for datacenter IPs (`MUSIC` search-only, `TVHTML5_SIMPLY` first for playback, then `WEB`, `WEBEMBEDDED`, `ANDROID_VR`, `TV` carrying OAuth).
+- The plugin version is declared in **exactly one place** (`.env`) and templated into `application.yml` at container start (`application.yml.tmpl` + `entrypoint.sh`), making version drift structurally impossible.
+- OAuth refresh token supplied via env var.
+
+### `token-minter` (scheduled one-shot)
+
+- Every ~6 hours: starts, runs headless Chromium against YouTube (trusted-session-generator approach), harvests fresh `poToken` + `visitorData`, pushes them to Lavalink **at runtime** via the youtube-source plugin's REST endpoint (no restart), writes them to the shared volume for cold starts, exits.
+- No Google account involved → nothing revocable. Independent of the OAuth layer.
+
+### `guardian` (Python service, ~400 lines)
+
+The supervisor, outside every failure domain it watches. Four duties, one module each:
+
+1. **Probe** — every 2 min: a canary track lookup against Lavalink REST + a health ping to the bot; also compares Lavalink player position between probes when state says "playing" (frozen-position = silent failure).
+2. **Classify** — maps failure signatures to playbook IDs F1–F9 (see the [Runbook](../operations/RUNBOOK.md)).
+3. **Act** — restarts sick containers via the Docker socket; triggers an immediate token-minter run on poToken rejection.
+4. **Alert** — Discord webhook to the admin channel with the playbook ID, diagnosis, and exact fix command when a human is required. Daily youtube-source GitHub release check (drift warning before breakage). Weekly heartbeat message proving the alert channel itself works.
+
+## Data Flow
+
+**Playback (happy path):**
+1. `/play` (or a dashboard command doc) → bot resolves the request
+2. Bot asks Lavalink to load the track; youtube-source hits YouTube carrying poToken + OAuth + client ordering
+3. Bot writes queue/player state to **Firestore first**, then instructs Lavalink to play — Firestore is the source of truth; containers hold only caches
+4. Track-end events arrive over the owned WebSocket → bot pops the next track from Firestore
+
+**Recovery (any container dies):**
+- `bot` restarts → reads Firestore + re-attaches Lavalink session → converges; audio continues during the gap via session resuming
+- `lavalink` restarts → guardian detects; bot's client reconnects with backoff and re-issues "play at position X" from Firestore → seconds of gap, then resumes
+- `guardian` restarts → Docker `restart: unless-stopped`; it is stateless
+- `token-minter` fails → previous token remains valid (token validity windows overlap)

--- a/docs/architecture/decisions/0001-owned-lavalink-client.md
+++ b/docs/architecture/decisions/0001-owned-lavalink-client.md
@@ -1,0 +1,19 @@
+# ADR-0001: Own the Lavalink client instead of using wavelink
+
+**Status:** Accepted · 2026-07-02
+
+## Context
+wavelink required monkey-patching for Discord DAVE voice encryption, and its
+connection-state model obscured silent playback failures (Class B outages).
+Recovery behavior — the whole point of this rewrite — lived in a dependency
+we didn't control.
+
+## Decision
+Write a thin client (~300–400 lines: REST for loads, WebSocket for events)
+in `services/bot/src/jacky/audio/`. We own reconnect, backoff, and session
+resuming outright.
+
+## Consequences
+(+) Full control over failure behavior; no patching. (−) We maintain
+protocol code; mitigated by Lavalink v4's stable REST/WS API and tests
+against a fake WebSocket.

--- a/docs/architecture/decisions/0002-potoken-sidecar.md
+++ b/docs/architecture/decisions/0002-potoken-sidecar.md
@@ -1,0 +1,18 @@
+# ADR-0002: poToken sidecar as an independent auth layer
+
+**Status:** Accepted · 2026-07-02
+
+## Context
+The dominant outage class (F2): Google periodically revokes the OAuth
+refresh token, and recovery needed a human for days. Any single credential
+is a single point of failure.
+
+## Decision
+Run a scheduled one-shot container (token-minter) that mints a poToken +
+visitorData with headless Chromium and pushes them to Lavalink at runtime.
+No Google account involved — nothing to revoke. OAuth stays as the second,
+independent layer; client ordering as the third.
+
+## Consequences
+(+) OAuth revocation no longer stops playback; layers fail independently.
+(−) ~400MB RAM spike during each ~1-minute mint (fits budget: one-shot).

--- a/docs/architecture/decisions/0003-crash-only-state.md
+++ b/docs/architecture/decisions/0003-crash-only-state.md
@@ -1,0 +1,19 @@
+# ADR-0003: Crash-only containers; state externalized
+
+**Status:** Accepted · 2026-07-02
+
+## Context
+The old bot accreted 1,443 lines of interleaved playback + watchdog code
+because in-process recovery required delicate reconnect choreography.
+
+## Decision
+No container holds durable state. Firestore is the source of truth (written
+BEFORE Lavalink is instructed); tokens live on a named volume. The guardian's
+only recovery verb is "restart." Bot and guardian each carry a small
+duplicated runtime helper rather than sharing a library — 15 lines of
+duplication beats cross-service packaging coupling at this scale.
+
+## Consequences
+(+) Recovery logic is trivial and centralized in the guardian; bot code is
+pure playback. (−) Firestore write latency is on the command path (~50ms,
+acceptable for a music bot).

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -1,0 +1,22 @@
+# Deployment
+
+The deploy contract on ANY Linux host with Docker:
+`git clone` → `cp deploy/.env.example deploy/.env` (fill it) → `make up`.
+No cloud-specific dependencies.
+
+## Current host: GCP e2-small
+- Project `personal-server-492701`, instance `personal-project-machine`
+- SSH: `gcloud compute ssh personal-project-machine --project=personal-server-492701`
+- Update deploy: `make deploy` (pulls master, rebuilds, restarts changed services)
+
+## Planned host: Hetzner (~€4/mo, better YouTube IP reputation tier)
+Migration = the deploy contract above + repoint the external uptime monitor.
+
+## Secrets
+Live only in `deploy/.env` on the host (git-ignored). `.env.example`
+documents every variable. Rotate `LAVALINK_PASSWORD` freely: `make up`
+re-propagates it to all services.
+
+## External uptime monitor (playbook F7)
+The VM cannot report its own death. A free-tier monitor (e.g. UptimeRobot)
+pings the guardian's heartbeat endpoint (M4) and emails/DMs on silence.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -1,0 +1,167 @@
+# Operator Runbook
+
+Guardian alerts carry a playbook ID (F1–F9). Find the ID below; run exactly
+what it says. All commands run on the VM from the repo root.
+
+> **Status:** Playbook IDs and automated responses land with M2 (token-minter)
+> and M4 (guardian). Until then, use the Confirm/Fix commands manually.
+
+## Playbook index
+
+| ID | Failure | Detected by | Automated response | Human needed? |
+|----|---------|-------------|--------------------|---------------|
+| F1 | poToken stale/rejected | Canary: bot-detection error | Trigger token-minter immediately, re-probe | No |
+| F2 | OAuth token revoked | Canary: "requires login" + OAuth 400 | Alert with one-command re-auth (`make reauth`) | **Yes** (~60s device flow) |
+| F3 | Plugin broken by YouTube JS change | Canary: signature/cipher errors | Alert with exact version bump; release watcher usually warns first | Yes (approve bump) |
+| F4 | Lavalink sick/dead | Canary timeout / Docker health | Guardian restarts container; bot reconnects + restores from Firestore | No |
+| F5 | Bot hung (gateway zombie) | Guardian's bot health ping | Guardian restarts bot container | No |
+| F6 | Silent playback (position frozen) | Position comparison across probes | Restart playback via bot; escalate to container restart on repeat | No |
+| F7 | VM down / Docker dead | External uptime monitor (free tier) pinging guardian's heartbeat URL | External email/DM | Yes |
+| F8 | Firestore unreachable | Bot + guardian error rates | Continue from in-memory cache; queue writes, flush on recovery; alert if sustained | No |
+| F9 | Alert channel broken | Weekly guardian heartbeat message | — | Missing heartbeat noticed by operator |
+
+## F1 — poToken stale or rejected
+
+**Alert looks like:** `[F1] poToken rejected — canary load hit YouTube bot
+detection. Triggered token-minter; re-probing in 2 min.`
+
+**Confirm:** `make logs s=lavalink | grep -i "sign in to confirm"` shows
+bot-detection errors on track loads.
+
+**Fix:** normally none — the guardian triggers an immediate token-minter run
+(M2) and re-probes. If the alert repeats:
+1. `make restart s=lavalink` — reload tokens from the shared volume
+2. Verify: play a test track, or `make logs s=guardian` shows the canary passing
+
+**While pending:** the OAuth layer (F2) and client ordering keep most
+playback working; only bot-detection-gated loads fail.
+
+## F2 — YouTube OAuth token revoked
+
+**Alert looks like:** `[F2] OAuth revoked — all loads failing with "requires
+login". Run: make reauth`
+
+**Confirm:** `make logs s=lavalink | grep -i oauth` shows
+`Invalid status code for oauth2 token fetch: 400` repeating.
+
+**Fix (~60s):**
+1. `make reauth` — prints a device code and URL (google.com/device)
+2. Open the URL on any machine, enter the code, approve with the bot's Google account
+3. The script writes the new token to `deploy/.env` and restarts Lavalink
+4. Verify: guardian posts `[F2 resolved]` after its next probe (≤2 min)
+
+**While pending:** poToken layer (F1) keeps most tracks playing; only
+sign-in-gated tracks fail.
+
+## F3 — youtube-source plugin broken by a YouTube JS change
+
+**Alert looks like:** `[F3] Signature extraction failing — youtube-source
+vX.Y.Z is stale. Bump YOUTUBE_PLUGIN_VERSION in deploy/.env and restart
+lavalink.` (The daily release watcher usually warns before breakage.)
+
+**Confirm:** `make logs s=lavalink | grep -iE "cipher|signature"` shows
+extraction/decipher errors on every load.
+
+**Fix (~2 min):**
+1. Find the latest release at github.com/lavalink-devs/youtube-source/releases
+2. Edit `YOUTUBE_PLUGIN_VERSION` in `deploy/.env` (the only place the version lives)
+3. `make restart s=lavalink` — the entrypoint re-renders `application.yml` from the template, so config and jar cannot drift
+4. Verify: play a test track; canary passes on the next probe
+
+**While pending:** all YouTube loads fail; no auth layer helps against a
+signature break. This is the highest-urgency human playbook.
+
+## F4 — Lavalink sick or dead
+
+**Alert looks like:** `[F4] Lavalink unresponsive (canary timeout) —
+restarting container.`
+
+**Confirm:** `make ps` shows `lavalink` unhealthy or restarting;
+`make logs s=lavalink` shows a crash, OOM kill, or startup failure.
+
+**Fix:** automated — the guardian restarts the container; the bot's client
+reconnects with backoff and re-issues "play at position X" from Firestore
+(seconds of gap). Manually:
+1. `make restart s=lavalink`
+2. Verify: `make ps` shows healthy; playback resumes
+
+**If it crash-loops:** check memory pressure (`docker stats`) — Lavalink's
+budget is ~800MB RSS on the 2GB VM — and inspect `make logs s=lavalink`
+for a config error before restarting again.
+
+## F5 — Bot hung (gateway zombie)
+
+**Alert looks like:** `[F5] Bot health ping timed out — restarting bot
+container.`
+
+**Confirm:** `make logs s=bot` shows no recent gateway activity or repeating
+heartbeat/resume failures; bot appears online in Discord but ignores commands.
+
+**Fix:** automated — the guardian restarts the bot container. Manually:
+1. `make restart s=bot`
+2. The bot is stateless: it rebuilds player state from Firestore and re-attaches to Lavalink's session (audio continues during the gap)
+3. Verify: bot responds to a command; guardian's next bot ping passes
+
+## F6 — Silent playback (position frozen)
+
+**Alert looks like:** `[F6] Player position frozen across probes while state
+says playing — restarting playback.`
+
+**Confirm:** Discord shows "now playing" but no audio; `make logs s=guardian`
+shows the position comparison failing between probes.
+
+**Fix:** automated — the guardian restarts playback via the bot, escalating
+to a container restart on repeat. Manually:
+1. Skip or replay the current track from Discord or the dashboard
+2. If still silent: `make restart s=lavalink`, then replay — the bot re-issues "play at position X" from Firestore
+3. Verify: position advances between the next two guardian probes
+
+## F7 — VM down / Docker dead
+
+**Alert looks like:** an email/DM from the **external uptime monitor** (not
+the guardian — the VM cannot report its own death): "guardian heartbeat URL
+unreachable".
+
+**Confirm:**
+`gcloud compute ssh personal-project-machine --project=personal-server-492701`
+— if SSH fails, check the instance in the GCP console.
+
+**Fix:**
+1. Start (or reset) the instance from the GCP console if it is stopped/wedged
+2. SSH in; if Docker died but the VM is up: `sudo systemctl restart docker`
+3. From the repo root: `make up` — every service is crash-only, so a cold start converges on its own
+4. Verify: `make ps` all healthy; uptime monitor reports the heartbeat URL reachable
+
+## F8 — Firestore unreachable
+
+**Alert looks like:** `[F8] Firestore error rate sustained for >5 min —
+serving from cache, queueing writes.`
+
+**Confirm:** `make logs s=bot | grep -i firestore` shows
+UNAVAILABLE/deadline-exceeded errors; check status.cloud.google.com for a
+Firestore incident.
+
+**Fix:** normally none — the bot continues from its in-memory cache and
+flushes queued writes when Firestore recovers. If sustained beyond a GCP
+incident window:
+1. Verify the service-account credentials referenced in `deploy/.env` are valid
+2. `make restart s=bot` after connectivity returns to force a clean state rebuild
+3. Verify: writes flush and the alert clears on the next probe
+
+**Impact while pending:** playback continues; dashboard sync and queue
+persistence lag until writes flush.
+
+## F9 — Alert channel broken
+
+**Alert looks like:** nothing — that is the failure. The guardian posts a
+weekly heartbeat message; its **absence** is the signal (calendar reminder
+recommended).
+
+**Confirm:** `make logs s=guardian | grep -i webhook` shows delivery errors
+(HTTP 4xx — webhook deleted or channel removed).
+
+**Fix:**
+1. Re-create the webhook in the Discord admin channel (Server Settings → Integrations → Webhooks)
+2. Update `ALERT_WEBHOOK_URL` in `deploy/.env`
+3. `make restart s=guardian`
+4. Verify: guardian posts its startup/heartbeat message to the channel

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -3,8 +3,14 @@
 Guardian alerts carry a playbook ID (F1–F9). Find the ID below; run exactly
 what it says. All commands run on the VM from the repo root.
 
-> **Status:** Playbook IDs and automated responses land with M2 (token-minter)
-> and M4 (guardian). Until then, use the Confirm/Fix commands manually.
+> **Status:** Playbook IDs and automated responses land with M2 (token-minter),
+> M3 (bot playback/state), and M4 (guardian). Until then, use the Confirm/Fix
+> commands manually.
+
+> **Reading logs:** `make logs s=<svc>` follows live output (Ctrl-C to exit;
+> silence after a few seconds means no match) and starts from the last 100
+> lines. To search further back without following:
+> `docker compose -f deploy/docker-compose.yml --env-file deploy/.env logs --tail=1000 <svc> | grep -i <pattern>`
 
 ## Playbook index
 
@@ -30,13 +36,18 @@ bot-detection errors on track loads.
 
 **Fix:** normally none — the guardian triggers an immediate token-minter run
 (M2) and re-probes. If the alert repeats:
-1. `make restart s=lavalink` — reload tokens from the shared volume
+1. `make restart s=lavalink` — reload tokens from the shared volume (effective from M2 — the volume is unread until token-minter lands)
 2. Verify: play a test track, or `make logs s=guardian` shows the canary passing
 
 **While pending:** the OAuth layer (F2) and client ordering keep most
 playback working; only bot-detection-gated loads fail.
 
 ## F2 — YouTube OAuth token revoked
+
+> **M1 caveat:** `make reauth` currently drives the LEGACY stack's script. For
+> the v2 stack, after completing the device flow, manually copy the printed
+> refresh token into `deploy/.env` (`YOUTUBE_OAUTH_REFRESH_TOKEN=...`) and run
+> `make restart s=lavalink`. The v2-native flow lands in M2.
 
 **Alert looks like:** `[F2] OAuth revoked — all loads failing with "requires
 login". Run: make reauth`
@@ -47,7 +58,7 @@ login". Run: make reauth`
 **Fix (~60s):**
 1. `make reauth` — prints a device code and URL (google.com/device)
 2. Open the URL on any machine, enter the code, approve with the bot's Google account
-3. The script writes the new token to `deploy/.env` and restarts Lavalink
+3. The script writes the new token to the legacy stack's root `.env` and restarts the legacy Lavalink container — for the v2 stack, apply the token manually per the caveat above
 4. Verify: guardian posts `[F2 resolved]` after its next probe (≤2 min)
 
 **While pending:** poToken layer (F1) keeps most tracks playing; only
@@ -76,7 +87,7 @@ signature break. This is the highest-urgency human playbook.
 **Alert looks like:** `[F4] Lavalink unresponsive (canary timeout) —
 restarting container.`
 
-**Confirm:** `make ps` shows `lavalink` unhealthy or restarting;
+**Confirm:** `make ps` shows `lavalink` restarting or exited;
 `make logs s=lavalink` shows a crash, OOM kill, or startup failure.
 
 **Fix:** automated — the guardian restarts the container; the bot's client
@@ -142,11 +153,10 @@ UNAVAILABLE/deadline-exceeded errors; check status.cloud.google.com for a
 Firestore incident.
 
 **Fix:** normally none — the bot continues from its in-memory cache and
-flushes queued writes when Firestore recovers. If sustained beyond a GCP
-incident window:
-1. Verify the service-account credentials referenced in `deploy/.env` are valid
-2. `make restart s=bot` after connectivity returns to force a clean state rebuild
-3. Verify: writes flush and the alert clears on the next probe
+flushes queued writes when Firestore recovers (lands with the M3 bot). If
+sustained beyond a GCP incident window:
+1. `make restart s=bot` after connectivity returns to force a clean state rebuild
+2. Verify: writes flush and the alert clears on the next probe
 
 **Impact while pending:** playback continues; dashboard sync and queue
 persistence lag until writes flush.

--- a/docs/operations/RUNBOOK.md
+++ b/docs/operations/RUNBOOK.md
@@ -44,10 +44,12 @@ playback working; only bot-detection-gated loads fail.
 
 ## F2 — YouTube OAuth token revoked
 
-> **M1 caveat:** `make reauth` currently drives the LEGACY stack's script. For
-> the v2 stack, after completing the device flow, manually copy the printed
-> refresh token into `deploy/.env` (`YOUTUBE_OAUTH_REFRESH_TOKEN=...`) and run
-> `make restart s=lavalink`. The v2-native flow lands in M2.
+> **M1 caveat:** `make reauth` currently drives the LEGACY stack's script,
+> which writes the token silently to the root `.env` (it is never printed to
+> the terminal). For the v2 stack: after completing the device flow, copy
+> `YOUTUBE_OAUTH_REFRESH_TOKEN` from the root `.env` into `deploy/.env`, then
+> run `make up` (a plain restart does NOT re-read env changes — the container
+> must be recreated). The v2-native flow lands in M2.
 
 **Alert looks like:** `[F2] OAuth revoked — all loads failing with "requires
 login". Run: make reauth`

--- a/docs/roadmap/FUTURE.md
+++ b/docs/roadmap/FUTURE.md
@@ -1,0 +1,6 @@
+# Roadmap (deferred — brainstorm before building)
+
+1. **Local audio nodes** — user-hosted Lavalink for low latency; `NodeProvider` second implementation with automatic fallback to the VM node on local-node disconnect.
+2. **Dashboard "summon"** — logged-in users click a previously-visited voice channel in the web UI to make the bot join it (within allowed guilds).
+3. **Search engine fix** — playlist URL → the URL's track plus the playlist's tracks as results; single-video URL → normal search with similar recommendations.
+4. **Spotify support.**

--- a/services/bot/README.md
+++ b/services/bot/README.md
@@ -3,6 +3,8 @@
 **What:** Discord-facing service — slash commands, voice, playback
 orchestration. Zero recovery logic (guardian's job, ADR-0003).
 
+**Status:** M1 skeleton — only `core/` exists; `commands/`, `audio/`, `state/` land in M3.
+
 **Run:** `pip install -e ".[dev]" && python -m jacky` · Tests: `pytest`
 
 **Depends on:** Lavalink (REST/WS, env: LAVALINK_HOST/PORT/PASSWORD),

--- a/services/bot/README.md
+++ b/services/bot/README.md
@@ -1,0 +1,11 @@
+# jacky-bot
+
+**What:** Discord-facing service — slash commands, voice, playback
+orchestration. Zero recovery logic (guardian's job, ADR-0003).
+
+**Run:** `pip install -e ".[dev]" && python -m jacky` · Tests: `pytest`
+
+**Depends on:** Lavalink (REST/WS, env: LAVALINK_HOST/PORT/PASSWORD),
+Firestore (source of truth), Discord gateway (DISCORD_TOKEN).
+Layout: `commands/` Discord handlers · `audio/` owned Lavalink client +
+NodeProvider · `state/` Firestore repositories · `core/` config/lifecycle.

--- a/services/bot/src/jacky/core/runtime.py
+++ b/services/bot/src/jacky/core/runtime.py
@@ -12,16 +12,23 @@ async def wait_for_shutdown(stop: asyncio.Event | None = None) -> None:
     """
     stop = stop or asyncio.Event()
     loop = asyncio.get_running_loop()
-    fallback_handlers: dict[int, object] = {}
+    loop_managed: list[int] = []
+    previous: dict[int, object] = {}
     for sig in (signal.SIGTERM, signal.SIGINT):
+        previous[sig] = signal.getsignal(sig)
         try:
             loop.add_signal_handler(sig, stop.set)
+            loop_managed.append(sig)
         except NotImplementedError:
             # Windows dev machines: no loop signal handlers; sync handler suffices.
-            fallback_handlers[sig] = signal.getsignal(sig)
             signal.signal(sig, lambda *_: stop.set())
     try:
         await stop.wait()
     finally:
-        for sig, previous in fallback_handlers.items():
-            signal.signal(sig, previous)
+        # Both registration paths mutate the process-global disposition
+        # (add_signal_handler installs its own C-level handler), so both
+        # must be undone or callers inherit handlers aimed at a dead event.
+        for sig in loop_managed:
+            loop.remove_signal_handler(sig)
+        for sig, prev in previous.items():
+            signal.signal(sig, prev)

--- a/services/guardian/README.md
+++ b/services/guardian/README.md
@@ -1,0 +1,11 @@
+# jacky-guardian
+
+**What:** The supervisor. Probes (canary track lookup + bot ping every
+2 min), classifies failures to playbook IDs F1–F9, restarts sick containers
+(Docker socket), alerts via Discord webhook with the exact fix.
+
+**Run:** `pip install -e ".[dev]" && python -m guardian` · Tests: `pytest`
+
+**Depends on:** Lavalink REST, bot health endpoint, Docker socket
+(mounted), ALERT_WEBHOOK_URL. One module per duty: `probe` / `classify` /
+`act` / `alert`.

--- a/services/guardian/README.md
+++ b/services/guardian/README.md
@@ -4,6 +4,8 @@
 2 min), classifies failures to playbook IDs F1–F9, restarts sick containers
 (Docker socket), alerts via Discord webhook with the exact fix.
 
+**Status:** M1 skeleton — runtime shell only; probe/classify/act/alert land in M4.
+
 **Run:** `pip install -e ".[dev]" && python -m guardian` · Tests: `pytest`
 
 **Depends on:** Lavalink REST, bot health endpoint, Docker socket

--- a/services/guardian/src/guardian/core/runtime.py
+++ b/services/guardian/src/guardian/core/runtime.py
@@ -12,16 +12,23 @@ async def wait_for_shutdown(stop: asyncio.Event | None = None) -> None:
     """
     stop = stop or asyncio.Event()
     loop = asyncio.get_running_loop()
-    fallback_handlers: dict[int, object] = {}
+    loop_managed: list[int] = []
+    previous: dict[int, object] = {}
     for sig in (signal.SIGTERM, signal.SIGINT):
+        previous[sig] = signal.getsignal(sig)
         try:
             loop.add_signal_handler(sig, stop.set)
+            loop_managed.append(sig)
         except NotImplementedError:
             # Windows dev machines: no loop signal handlers; sync handler suffices.
-            fallback_handlers[sig] = signal.getsignal(sig)
             signal.signal(sig, lambda *_: stop.set())
     try:
         await stop.wait()
     finally:
-        for sig, previous in fallback_handlers.items():
-            signal.signal(sig, previous)
+        # Both registration paths mutate the process-global disposition
+        # (add_signal_handler installs its own C-level handler), so both
+        # must be undone or callers inherit handlers aimed at a dead event.
+        for sig in loop_managed:
+            loop.remove_signal_handler(sig)
+        for sig, prev in previous.items():
+            signal.signal(sig, prev)

--- a/services/lavalink/Dockerfile
+++ b/services/lavalink/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/lavalink-devs/lavalink:4
+USER root
+COPY application.yml.tmpl /opt/Lavalink/application.yml.tmpl
+COPY entrypoint.sh /opt/Lavalink/entrypoint.sh
+RUN chmod +x /opt/Lavalink/entrypoint.sh
+USER lavalink
+ENTRYPOINT ["/opt/Lavalink/entrypoint.sh"]

--- a/services/lavalink/README.md
+++ b/services/lavalink/README.md
@@ -2,6 +2,8 @@
 
 **What:** Lavalink v4 + youtube-source plugin — the audio engine.
 
+**Status:** Active from M1 — poToken volume input becomes live in M2.
+
 **Config:** `application.yml.tmpl` rendered at container start; the plugin
 version comes ONLY from `.env` (`YOUTUBE_PLUGIN_VERSION`) so config/jar
 drift is impossible. Secrets resolve via Spring env placeholders — never

--- a/services/lavalink/README.md
+++ b/services/lavalink/README.md
@@ -1,0 +1,11 @@
+# lavalink
+
+**What:** Lavalink v4 + youtube-source plugin — the audio engine.
+
+**Config:** `application.yml.tmpl` rendered at container start; the plugin
+version comes ONLY from `.env` (`YOUTUBE_PLUGIN_VERSION`) so config/jar
+drift is impossible. Secrets resolve via Spring env placeholders — never
+written to disk.
+
+**Depends on:** YouTube (poToken via token-minter volume + OAuth env +
+client ordering — see ADR-0002).

--- a/services/lavalink/application.yml.tmpl
+++ b/services/lavalink/application.yml.tmpl
@@ -1,0 +1,44 @@
+server:
+  port: 2333
+  address: 0.0.0.0
+
+lavalink:
+  plugins:
+    - dependency: "dev.lavalink.youtube:youtube-plugin:__YOUTUBE_PLUGIN_VERSION__"
+      repository: "https://maven.lavalink.dev/releases"
+      snapshot: false
+  server:
+    password: "${LAVALINK_SERVER_PASSWORD}"
+    sources:
+      youtube: false  # handled by youtube-plugin above
+
+plugins:
+  youtube:
+    enabled: true
+    allowSearch: true
+    allowDirectVideoIds: true
+    allowDirectPlaylistIds: true
+    # Client order matters: Lavalink tries top-to-bottom until one resolves.
+    # MUSIC: search-only. TVHTML5_SIMPLY first for playback: TV-class IP
+    # reputation survives datacenter IPs. TV last: carries OAuth for
+    # sign-in-gated streams (metadata support: none, useless alone).
+    clients:
+      - MUSIC
+      - TVHTML5_SIMPLY
+      - WEB
+      - WEBEMBEDDED
+      - ANDROID_VR
+      - TV
+    clientOptions:
+      MUSIC:
+        playback: false
+        videoLoading: false
+    oauth:
+      enabled: true
+      refreshToken: "${YOUTUBE_OAUTH_REFRESH_TOKEN:}"
+      skipInitialization: false
+
+logging:
+  level:
+    root: INFO
+    lavalink: INFO

--- a/services/lavalink/entrypoint.sh
+++ b/services/lavalink/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+: "${YOUTUBE_PLUGIN_VERSION:?YOUTUBE_PLUGIN_VERSION must be set (see deploy/.env.example)}"
+sed "s|__YOUTUBE_PLUGIN_VERSION__|${YOUTUBE_PLUGIN_VERSION}|g" \
+    /opt/Lavalink/application.yml.tmpl > /tmp/application.yml
+# classpath:/ keeps the jar's built-in defaults (incl. the spring.config.import
+# property Spring Cloud requires); our rendered file, listed last, overrides them.
+export SPRING_CONFIG_LOCATION="classpath:/,file:/tmp/application.yml"
+exec java -jar /opt/Lavalink/Lavalink.jar

--- a/services/lavalink/entrypoint.sh
+++ b/services/lavalink/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eu
 : "${YOUTUBE_PLUGIN_VERSION:?YOUTUBE_PLUGIN_VERSION must be set (see deploy/.env.example)}"
+case "$YOUTUBE_PLUGIN_VERSION" in
+  *[!A-Za-z0-9._-]*) echo "YOUTUBE_PLUGIN_VERSION contains invalid characters" >&2; exit 1 ;;
+esac
 sed "s|__YOUTUBE_PLUGIN_VERSION__|${YOUTUBE_PLUGIN_VERSION}|g" \
     /opt/Lavalink/application.yml.tmpl > /tmp/application.yml
 # classpath:/ keeps the jar's built-in defaults (incl. the spring.config.import


### PR DESCRIPTION
## What

The stacked M1 PRs (#25 deploy, #26 CI, #27 docs) were merged into each other in ascending order, so their content never reached `master` — only #24's scaffolds did. This PR brings the complete M1 milestone to master, plus one CI-caught fix:

- **fix(runtime):** Linux CI on #26 caught that `loop.add_signal_handler` also mutates the process-global signal disposition — restoration now covers both registration paths (the Windows-only fallback restore was insufficient). Verified in python:3.11 Linux containers.

## Why

Closes the M1 Foundation milestone (#19–#22 content). Master's CI is currently red on the runtime tests; this makes it green.

## Test evidence

- Windows: bot 4 passed, guardian 4 passed; ruff clean; compose config OK
- Linux (python:3.11-slim containers): bot 4 passed, guardian 4 passed — the previously-failing `test_restores_prior_signal_handlers` now passes on the loop path
- This PR runs the full CI matrix as proof

## Checklist

- [x] After merging, all four M1 feature branches can be deleted
- [x] No secrets in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate the new v2 crash-only Docker stack, CI workflows, and documentation into master while fixing signal handler cleanup in the async runtimes for Linux compatibility.

New Features:
- Introduce a Docker Compose-based deployment stack for bot, guardian, and Lavalink services with a tokens volume and Makefile-driven operations.
- Add initial service-level READMEs plus architecture, ADR, runbook, deployment, and roadmap docs describing the v2 stability-focused design.
- Set up GitHub Actions CI for linting, testing, Docker build validation, and compose config checks, along with standardized PR and issue templates.

Bug Fixes:
- Ensure async shutdown helpers in bot and guardian correctly restore prior signal handlers and remove loop-managed handlers on Linux.

Enhancements:
- Update top-level README and CLAUDE project docs to describe the v2 architecture, repo layout, and environment variable contracts, clarifying legacy vs new stack.